### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ hg-commit-sanity: Mercurial Commit Sanity
 
 .. image:: https://api.travis-ci.org/paylogic/hg-commit-sanity.png
    :target: https://travis-ci.org/paylogic/hg-commit-sanity
-.. image:: https://pypip.in/v/hg-commit-sanity/badge.png
+.. image:: https://img.shields.io/pypi/v/hg-commit-sanity.svg
    :target: https://crate.io/packages/hg-commit-sanity/
 .. image:: https://coveralls.io/repos/paylogic/hg-commit-sanity/badge.png?branch=master
    :target: https://coveralls.io/r/paylogic/hg-commit-sanity


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20hg-commit-sanity))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `hg-commit-sanity`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.